### PR TITLE
Add stock data extraction script

### DIFF
--- a/pull_stock_data.py
+++ b/pull_stock_data.py
@@ -1,0 +1,14 @@
+import yfinance as yf
+
+# Load SPY ETF
+ticker = yf.Ticker("SPY")
+
+# Get OHLCV data
+ohlc = ticker.history(start="2022-01-01", end="2024-12-31", interval="1d")
+
+# Get dividend data
+dividends = ticker.dividends.loc["2022-01-01":"2024-12-31"]
+
+# Save to CSV
+ohlc.to_csv("SPY_ohlc.csv")
+dividends.to_csv("SPY_dividends.csv")


### PR DESCRIPTION
## Summary
- add `pull_stock_data.py` example showing how to download OHLCV and dividends from Yahoo Finance via yfinance

## Testing
- `python pull_stock_data.py` *(fails: CONNECT tunnel failed: 403)*

------
https://chatgpt.com/codex/tasks/task_e_686a7ed8e0d88330849cbd5600ce7e9b