### PR TITLE
Add CLI arguments for ticker symbol and dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,22 @@ pip install -r requirements.txt
 
 ## Running the script
 
-Execute the script with Python to download the data:
+Execute the script with Python to download the data. You can optionally
+specify the ticker symbol and date range using command-line arguments:
 
 ```bash
+# Download SPY data using the defaults
 python pull_stock_data.py
+
+# Download AAPL data for a custom date range
+python pull_stock_data.py --ticker AAPL --start 2023-01-01 --end 2023-06-30
 ```
 
-This will generate the following files in the repository directory:
+The script generates two CSV files in the repository directory named after
+the ticker symbol:
 
-* `SPY_ohlc.csv` – daily OHLCV data
-* `SPY_dividends.csv` – dividend data
+* `<TICKER>_ohlc.csv` – daily OHLCV data
+* `<TICKER>_dividends.csv` – dividend data
 
-You can adjust the ticker or date ranges by editing `pull_stock_data.py`.
+If no arguments are supplied, it defaults to downloading SPY data from
+`2022-01-01` through `2024-12-31`.

--- a/pull_stock_data.py
+++ b/pull_stock_data.py
@@ -1,14 +1,17 @@
+import argparse
 import yfinance as yf
 
-# Load SPY ETF
-ticker = yf.Ticker("SPY")
+parser = argparse.ArgumentParser(description="Download historical stock data")
+parser.add_argument("--ticker", default="SPY", help="Ticker symbol to download")
+parser.add_argument("--start", default="2022-01-01", help="Start date in YYYY-MM-DD format")
+parser.add_argument("--end", default="2024-12-31", help="End date in YYYY-MM-DD format")
+args = parser.parse_args()
+ticker = yf.Ticker(args.ticker)
 
-# Get OHLCV data
-ohlc = ticker.history(start="2022-01-01", end="2024-12-31", interval="1d")
+ohlc = ticker.history(start=args.start, end=args.end, interval="1d")
 
-# Get dividend data
-dividends = ticker.dividends.loc["2022-01-01":"2024-12-31"]
+dividends = ticker.dividends.loc[args.start:args.end]
 
 # Save to CSV
-ohlc.to_csv("SPY_ohlc.csv")
-dividends.to_csv("SPY_dividends.csv")
+ohlc.to_csv(f"{args.ticker}_ohlc.csv")
+dividends.to_csv(f"{args.ticker}_dividends.csv")


### PR DESCRIPTION
## Summary
- add argparse logic for ticker/date range to `pull_stock_data.py`
- explain new CLI usage in README

## Testing
- `pip install -r requirements.txt`
- `python pull_stock_data.py --ticker SPY --start 2022-01-01 --end 2022-01-10` *(fails: CONNECT tunnel failed for fc.yahoo.com)*

------
https://chatgpt.com/codex/tasks/task_e_686a83e1e2fc8330911f5c6e6eac4c03