### PR TITLE
Add Streamlit stock downloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Ignore generated CSV files
-SPY_ohlc.csv
-SPY_dividends.csv
+*.csv
 
 # Python artifacts
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -39,3 +39,13 @@ This will generate the following files in the repository directory:
 * `SPY_dividends.csv` – dividend data
 
 You can adjust the ticker or date ranges by editing `pull_stock_data.py`.
+
+## Using the Streamlit interface
+
+You can also download data through the Streamlit app. Run:
+
+```bash
+streamlit run streamlit_app.py
+```
+
+Choose the ticker and dates in the app. The resulting CSV will be saved as `<TICKER>_<START>_<END>.csv`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 yfinance
 pandas
+
+streamlit

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,22 @@
+import streamlit as st
+import yfinance as yf
+from datetime import date
+
+st.title("Stock Data Downloader")
+
+# Inputs
+symbol = st.text_input("Ticker symbol", "SPY")
+start_date = st.date_input("Start date", value=date(2022, 1, 1))
+end_date = st.date_input("End date", value=date.today())
+
+if st.button("Download Data"):
+    if not symbol:
+        st.error("Please enter a ticker symbol")
+    elif start_date >= end_date:
+        st.error("Start date must be before end date")
+    else:
+        data = yf.download(symbol, start=start_date, end=end_date, interval="1d")
+        file_name = f"{symbol}_{start_date}_{end_date}.csv"
+        data.to_csv(file_name)
+        st.success(f"Data saved to {file_name}")
+        st.dataframe(data)


### PR DESCRIPTION
## Summary
- ignore csv files
- add a Streamlit script for downloading arbitrary ticker data
- document new Streamlit interface
- include Streamlit dependency

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a87a122a4833095aa528b86c79ae0