### PR TITLE
Add bash run example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,10 @@ You can also download data through the Streamlit app. Run:
 streamlit run streamlit_app.py
 ```
 
+From a Bash shell you can also start it with:
+
+```bash
+bash -c 'streamlit run streamlit_app.py'
+```
+
 Choose the ticker and dates in the app. The resulting CSV will be saved as `<TICKER>_<START>_<END>.csv`.


### PR DESCRIPTION
## Summary
- document running the Streamlit app from bash

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a8a02032c83308fe6b1d986da1fa3