### PR TITLE
Implement monthly first-day feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This repository contains a small script for downloading historical data for the
 SPY ETF using [yfinance](https://github.com/ranaroussi/yfinance). The script
-retrieves daily OHLCV data and dividend information and stores them as CSV
-files.
+retrieves price data and dividend information and stores them as CSV files. By
+default the price data includes only the first trading day of each month.
 
 ## Requirements
 
@@ -35,8 +35,8 @@ python pull_stock_data.py
 
 This will generate the following files in the repository directory:
 
-* `SPY_ohlc.csv` – daily OHLCV data
-* `SPY_dividends.csv` – dividend data
+* `SPY_monthly_ohlc.csv` – the first trading day of each month
+* `SPY_dividends.csv` – dividend data for the same period
 
 You can adjust the ticker or date ranges by editing `pull_stock_data.py`.
 

--- a/pull_stock_data.py
+++ b/pull_stock_data.py
@@ -1,19 +1,49 @@
+"""Utility for downloading SPY price data and dividends."""
+
+from __future__ import annotations
+
+import pandas as pd
 import yfinance as yf
 
 
+def filter_first_day_month(data: pd.DataFrame) -> pd.DataFrame:
+    """Return the first available row for each month.
+
+    Parameters
+    ----------
+    data:
+        DataFrame indexed by date containing daily price information.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with the first row for each month in ``data``.
+    """
+
+    if not isinstance(data.index, pd.DatetimeIndex):
+        raise TypeError("Data index must be a DatetimeIndex")
+
+    # Resample to the first calendar day of each month and select the first row.
+    monthly = data.resample("MS").first()
+    return monthly
+
+
 def main() -> None:
-    """Download SPY data and save to CSV files."""
-    # Load SPY ETF
+    """Download monthly SPY data and dividend information."""
+    start = "2022-01-01"
+    end = "2024-12-31"
+
     ticker = yf.Ticker("SPY")
 
-    # Get OHLCV data
-    ohlc = ticker.history(start="2022-01-01", end="2024-12-31", interval="1d")
+    # Get daily OHLCV data and reduce to first row of each month
+    daily = ticker.history(start=start, end=end, interval="1d")
+    monthly = filter_first_day_month(daily)
 
-    # Get dividend data
-    dividends = ticker.dividends.loc["2022-01-01":"2024-12-31"]
+    # Get dividend data within the period
+    dividends = ticker.dividends.loc[start:end]
 
-    # Save to CSV
-    ohlc.to_csv("SPY_ohlc.csv")
+    # Save to CSV files
+    monthly.to_csv("SPY_monthly_ohlc.csv")
     dividends.to_csv("SPY_dividends.csv")
 
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2,12 +2,15 @@ import streamlit as st
 import yfinance as yf
 from datetime import date
 
+from pull_stock_data import filter_first_day_month
+
 st.title("Stock Data Downloader")
 
 # Inputs
 symbol = st.text_input("Ticker symbol", "SPY")
 start_date = st.date_input("Start date", value=date(2022, 1, 1))
 end_date = st.date_input("End date", value=date.today())
+monthly_only = st.checkbox("First day of each month only", value=True)
 
 if st.button("Download Data"):
     if not symbol:
@@ -16,6 +19,8 @@ if st.button("Download Data"):
         st.error("Start date must be before end date")
     else:
         data = yf.download(symbol, start=start_date, end=end_date, interval="1d")
+        if monthly_only:
+            data = filter_first_day_month(data)
         file_name = f"{symbol}_{start_date}_{end_date}.csv"
         data.to_csv(file_name)
         st.success(f"Data saved to {file_name}")

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,12 @@
+import pandas as pd
+from pull_stock_data import filter_first_day_month
+
+
+def test_filter_first_day_month():
+    dates = pd.date_range('2024-01-01', '2024-03-31', freq='D')
+    df = pd.DataFrame({'close': range(len(dates))}, index=dates)
+    result = filter_first_day_month(df)
+    assert len(result) == 3
+    assert result.index[0] == pd.Timestamp('2024-01-01')
+    assert result.index[1] == pd.Timestamp('2024-02-01')
+    assert result.index[2] == pd.Timestamp('2024-03-01')


### PR DESCRIPTION
## Summary
- include new `filter_first_day_month` helper
- store SPY monthly OHLC data and dividends
- update streamlit app with checkbox for monthly view
- document new behaviour in README
- add basic unit test for helper function

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a8d88ed1c83309a1fc608ec4ace89