### PR TITLE
Add dividend preview to Streamlit app

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,7 @@ From a Bash shell you can also start it with:
 bash -c 'streamlit run streamlit_app.py'
 ```
 
-Choose the ticker and dates in the app. The resulting CSV will be saved as `<TICKER>_<START>_<END>.csv`.
+Choose the ticker and dates in the app. The resulting OHLC data will be saved as
+`<TICKER>_<START>_<END>.csv` and previewed in the browser. You can also opt to
+download dividend information for the same period, which will be saved as
+`<TICKER>_dividends_<START>_<END>.csv` and previewed below the price data.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -11,6 +11,7 @@ symbol = st.text_input("Ticker symbol", "SPY")
 start_date = st.date_input("Start date", value=date(2022, 1, 1))
 end_date = st.date_input("End date", value=date.today())
 monthly_only = st.checkbox("First day of each month only", value=True)
+show_dividends = st.checkbox("Download dividends", value=True)
 
 if st.button("Download Data"):
     if not symbol:
@@ -25,3 +26,13 @@ if st.button("Download Data"):
         data.to_csv(file_name)
         st.success(f"Data saved to {file_name}")
         st.dataframe(data)
+        if show_dividends:
+            ticker = yf.Ticker(symbol)
+            dividends = ticker.dividends.loc[str(start_date):str(end_date)]
+            div_file = f"{symbol}_dividends_{start_date}_{end_date}.csv"
+            if not dividends.empty:
+                dividends.to_csv(div_file)
+                st.success(f"Dividends saved to {div_file}")
+                st.dataframe(dividends)
+            else:
+                st.info("No dividend data found for the selected period")


### PR DESCRIPTION
## Summary
- extend the Streamlit interface to optionally download and preview dividend data
- document dividend download in README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a90828d608330b15c535e9fd52eb4