### PR TITLE
Support combined dividends dataset in Streamlit

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ bash -c 'streamlit run streamlit_app.py'
 ```
 
 Choose the ticker and dates in the app. The resulting OHLC data will be saved as
-`<TICKER>_<START>_<END>.csv` and previewed in the browser. You can also opt to
-download dividend information for the same period, which will be saved as
-`<TICKER>_dividends_<START>_<END>.csv` and previewed below the price data.
+`<TICKER>_<START>_<END>.csv` and previewed in the browser. If you select the
+**Download dividends** option, a single file containing both closing prices and
+dividends will be created. The combined column is named
+`ClosingPrice_Dividends` and the file will be stored in the directory specified
+in the **Download directory** text box (defaults to your Downloads folder).

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,6 +1,7 @@
 import streamlit as st
 import yfinance as yf
 from datetime import date
+from pathlib import Path
 import pandas as pd
 
 from pull_stock_data import filter_first_day_month
@@ -13,6 +14,10 @@ start_date = st.date_input("Start date", value=date(2022, 1, 1))
 end_date = st.date_input("End date", value=date.today())
 monthly_only = st.checkbox("First day of each month only", value=True)
 show_dividends = st.checkbox("Download dividends", value=True)
+download_dir = st.text_input(
+    "Download directory",
+    value=str(Path.home() / "Downloads"),
+)
 
 if st.button("Download Data"):
     if not symbol:
@@ -24,25 +29,26 @@ if st.button("Download Data"):
         data.index = data.index.tz_localize(None)
         if monthly_only:
             data = filter_first_day_month(data)
-        file_name = f"{symbol}_{start_date}_{end_date}.csv"
-        data.to_csv(file_name)
-        st.success(f"Data saved to {file_name}")
+
+        out_dir = Path(download_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+
         if show_dividends:
             ticker = yf.Ticker(symbol)
             dividends = ticker.dividends.loc[str(start_date):str(end_date)]
             dividends.index = dividends.index.tz_localize(None)
-            div_file = f"{symbol}_dividends_{start_date}_{end_date}.csv"
-            if not dividends.empty:
-                dividends.to_csv(div_file)
-                st.success(f"Dividends saved to {div_file}")
-            else:
-                st.info("No dividend data found for the selected period")
-            union_df = pd.concat(
+            combined = pd.concat(
                 [
-                    dividends.to_frame(name="Dividends"),
-                    data[["Close"]].rename(columns={"Close": "Dividends"}),
+                    data["Close"].rename("ClosingPrice_Dividends"),
+                    dividends.rename("ClosingPrice_Dividends"),
                 ]
             ).sort_index()
-            st.dataframe(union_df)
+            file_name = out_dir / f"{symbol}_ClosingPrice_Dividends_{start_date}_{end_date}.csv"
+            combined.to_csv(file_name)
+            st.success(f"Data saved to {file_name}")
+            st.dataframe(combined)
         else:
+            file_name = out_dir / f"{symbol}_{start_date}_{end_date}.csv"
+            data.to_csv(file_name)
+            st.success(f"Data saved to {file_name}")
             st.dataframe(data)


### PR DESCRIPTION
## Summary
- add `download_dir` input in Streamlit app
- download a single combined dataset of closing prices and dividends
- document new behaviour in README

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a97d10f9883309a0279e066ebff85