### PR TITLE
Handle multi-ticker input

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ From a Bash shell you can also start it with:
 bash -c 'streamlit run streamlit_app.py'
 ```
 
-Choose the ticker and dates in the app. The resulting OHLC data will be saved as
+Choose a single ticker and the date range in the app. The resulting OHLC data will be saved as
 `<TICKER>_<START>_<END>.csv` and previewed in the browser. If you select the
 **Download dividends** option, a single file containing both closing prices and
 dividends will be created. The combined column is named

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -27,6 +27,9 @@ if st.button("Download Data"):
     else:
         data = yf.download(symbol, start=start_date, end=end_date, interval="1d")
         data.index = data.index.tz_localize(None)
+        if isinstance(data["Close"], pd.DataFrame):
+            st.error("Multiple tickers are not supported. Please enter one symbol.")
+            st.stop()
         if monthly_only:
             data = filter_first_day_month(data)
 


### PR DESCRIPTION
## Summary
- safeguard Streamlit app from multi-ticker input so renaming works
- clarify single ticker expectation in README

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a98f77268833082e7190238613616